### PR TITLE
Allow for npm install -g gitlet

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 
   "bin": {
     "gitlet": "./gitlet.js"
-  }
+  },
 
   "scripts": {
     "test": "node_modules/jasmine-node/bin/jasmine-node spec/"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
     "url": "https://github.com/maryrosecook/gitlet.git"
   },
 
+  "bin": {
+    "gitlet": "./gitlet.js"
+  }
+
   "scripts": {
     "test": "node_modules/jasmine-node/bin/jasmine-node spec/"
   },


### PR DESCRIPTION
This should get `npm install -g gitlet` to work once you `npm publish` it...

note: you should probably consider creating a `/bin/gitlet.js` that runs your command line interface, and make the rest of your project a library that can be used from other node modules.

Nide work by the way.