### PR TITLE
Corrected typo: thet -> the

### DIFF
--- a/docs/gitlet.html
+++ b/docs/gitlet.html
@@ -1610,7 +1610,7 @@ differences to the checked out branch.</p>
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-95">&#182;</a>
               </div>
-              <p>Get the <code>receiverHash</code>, the hash of the commit that thet
+              <p>Get the <code>receiverHash</code>, the hash of the commit that the
 current branch is on.</p>
 
             </div>


### PR DESCRIPTION
Changed "the hash of the commit that thet current branch is on" to "the hash of the commit that the current branch is on".