### PR TITLE
Write errors to stderr

### DIFF
--- a/gitlet.js
+++ b/gitlet.js
@@ -1971,6 +1971,6 @@ if (require.main === module) {
       console.log(result);
     }
   } catch (e) {
-    console.log(e.toString());
+    console.error(e.toString());
   }
 }


### PR DESCRIPTION
Changed the way errors loggin in `tryCath` block:
```js
console.log -> console.error
```