### PR TITLE
fix gitlet: improve check in files.read

### DIFF
--- a/gitlet.js
+++ b/gitlet.js
@@ -1773,7 +1773,7 @@ var files = {
   // **read()** returns the contents of the file at `path` as a
   // string.  It returns `undefined` if the file doesn't exist.
   read: function(path) {
-    if (fs.existsSync(path)) {
+    if (fs.existsSync(path) && fs.statSync(path).isFile()) {
       return fs.readFileSync(path, "utf8");
     }
   },

--- a/spec/init.spec.js
+++ b/spec/init.spec.js
@@ -27,6 +27,13 @@ describe("init", function() {
     testUtil.expectFile(__dirname + "/testData/repo1/.gitlet/config",
                         "[core]\n  bare = false\n");
   });
+  /*
+  it("should not crash when config is a directory", function() {
+      var dir = __dirname + "/testData/repo1/";
+      fs.createDirSync(dir + 'config');
+      g.init();
+    });
+    */
 
   describe("bare repos", function() {
     it("should put all gitlet files and folders in root if specify bare", function() {
@@ -40,4 +47,5 @@ describe("init", function() {
                           "[core]\n  bare = true\n");
     });
   });
+  
 });


### PR DESCRIPTION
When `config` is exist and it is not file, error occurs:
```
Error: EISDIR, illegal operation on a directory
```