### PR TITLE
add main field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "url": "https://github.com/maryrosecook/gitlet.git"
   },
 
+  "main": "./gitlet.js",
+
   "bin": {
     "gitlet": "./gitlet.js"
   },


### PR DESCRIPTION
This allows hackers trying to use the programmatic api to do

```js
const git = require('gitlet')
```

instead of

```js
const git = require('gitlet/gitlet')
```